### PR TITLE
Made the git helper available to other plugins.

### DIFF
--- a/fields.php
+++ b/fields.php
@@ -6,9 +6,9 @@ return [
   'gitLog' => [
     'computed' => [
 
-      'gitLog' => function () use ($gitHelper) {
+      'gitLog' => function () {
         // Gather all commits and format as valid JSOn
-        $log = $gitHelper->getRepo()->log('{%n \"hash\": \"%h\",%n \"date\": \"%at\",%n \"message\": \"%s\",%n \"author\": \"%an\"},');
+        $log = site()->git()->getRepo()->log('{%n \"hash\": \"%h\",%n \"date\": \"%at\",%n \"message\": \"%s\",%n \"author\": \"%an\"},');
         $log = rtrim($log,",");
         $log = "[{$log}]";
         $log = json_decode($log, true);
@@ -35,7 +35,8 @@ return [
       //   return $this->model()->blueprint();
       // },
 
-      'gitRevisions' => function () use ($gitHelper) {
+      'gitRevisions' => function () {
+        $gitHelper = site()->git();
         $parent = $this->model();
 
         // Get the relative content file path

--- a/hooks.php
+++ b/hooks.php
@@ -6,133 +6,133 @@ return [
   /**
   * Page-Hooks
   */
-  'page.create:after' => function ($page) use ($gitHelper) {
-    $gitHelper->changeHandler("Created Page: {$page->id()}");
+  'page.create:after' => function ($page) {
+    site()->git()->changeHandler("Created Page: {$page->id()}");
   },
-  'page.update:after' => function ($newPage,$oldPage) use ($gitHelper) {
-    $gitHelper->changeHandler("Edited Page: {$newPage->id()}");
+  'page.update:after' => function ($newPage,$oldPage) {
+    site()->git()->changeHandler("Edited Page: {$newPage->id()}");
   },
-  'page.delete:after' => function ($status, $page) use ($gitHelper) {
-    $gitHelper->changeHandler("Deleted Page: {$page->id()}");
+  'page.delete:after' => function ($status, $page) {
+    site()->git()->changeHandler("Deleted Page: {$page->id()}");
   },
-  'page.changeNum:after' => function ($newPage,$oldPage) use ($gitHelper) {
+  'page.changeNum:after' => function ($newPage,$oldPage) {
     $oldNum = $oldPage->num() ?? "None";
-    $gitHelper->changeHandler("Sorted Page: {$newPage->id()} ({$oldNum} → {$newPage->num()})");
+    site()->git()->changeHandler("Sorted Page: {$newPage->id()} ({$oldNum} → {$newPage->num()})");
   },
-  'page.changeSlug:after' => function ($newPage,$oldPage) use ($gitHelper) {
+  'page.changeSlug:after' => function ($newPage,$oldPage) {
     $oldSlug = $oldPage->slug() ?? "None";
-    $gitHelper->changeHandler("Changed Slug: {$newPage->id()} ({$oldSlug} → {$newPage->slug()})");
+    site()->git()->changeHandler("Changed Slug: {$newPage->id()} ({$oldSlug} → {$newPage->slug()})");
   },
-  'page.changeStatus:after' => function ($newPage,$oldPage) use ($gitHelper) {
+  'page.changeStatus:after' => function ($newPage,$oldPage) {
     $oldStatus = $oldPage->status() ?? "None";
-    $gitHelper->changeHandler("Changed Status: {$newPage->id()} ({$oldStatus} → {$newPage->status()})");
+    site()->git()->changeHandler("Changed Status: {$newPage->id()} ({$oldStatus} → {$newPage->status()})");
   },
-  'page.changeTemplate:after' => function ($newPage,$oldPage) use ($gitHelper) {
+  'page.changeTemplate:after' => function ($newPage,$oldPage) {
     $oldTemplate = $oldPage->template() ?? "None";
-    $gitHelper->changeHandler("Changed Template: {$newPage->id()} ({$oldTemplate} → {$newPage->template()})");
+    site()->git()->changeHandler("Changed Template: {$newPage->id()} ({$oldTemplate} → {$newPage->template()})");
   },
-  'page.changeTitle:after' => function ($newPage,$oldPage) use ($gitHelper) {
+  'page.changeTitle:after' => function ($newPage,$oldPage) {
     $oldTitle = $oldPage->title() ?? "None";
-    $gitHelper->changeHandler("Changed Title: {$newPage->id()} ({$oldTitle} → {$newPage->title()})");
+    site()->git()->changeHandler("Changed Title: {$newPage->id()} ({$oldTitle} → {$newPage->title()})");
   },
 
   /**
   * File-Hooks
   */
-  'file.create:after' => function ($file) use ($gitHelper) {
-    $gitHelper->changeHandler("Uploaded File: {$file->id()}");
+  'file.create:after' => function ($file) {
+    site()->git()->changeHandler("Uploaded File: {$file->id()}");
   },
-  'file.delete:after' => function ($status, $file) use ($gitHelper) {
-    $gitHelper->changeHandler("Deleted File: {$file->id()}");
+  'file.delete:after' => function ($status, $file) {
+    site()->git()->changeHandler("Deleted File: {$file->id()}");
   },
-  'file.changeName:after' => function ($newFile,$oldFile) use ($gitHelper) {
+  'file.changeName:after' => function ($newFile,$oldFile) {
     $oldFilename = $oldFile->filename() ?? "None";
-    $gitHelper->changeHandler("Changed Filename: {$newFile->id()} ({$oldFilename} → {$newFile->filename()})");
+    site()->git()->changeHandler("Changed Filename: {$newFile->id()} ({$oldFilename} → {$newFile->filename()})");
   },
-  'file.changeSort:after' => function ($newFile,$oldFile) use ($gitHelper) {
+  'file.changeSort:after' => function ($newFile,$oldFile) {
     $oldSort = $oldFile->sort() ?? "None";
-    $gitHelper->changeHandler("Sorted File: {$newFile->id()} ({$oldSort} → {$newFile->sort()})");
+    site()->git()->changeHandler("Sorted File: {$newFile->id()} ({$oldSort} → {$newFile->sort()})");
   },
-  'file.update:after' => function ($newFile,$oldFile) use ($gitHelper) {
-    $gitHelper->changeHandler("Edited File-Metadata: {$newFile->id()}");
+  'file.update:after' => function ($newFile,$oldFile) {
+    site()->git()->changeHandler("Edited File-Metadata: {$newFile->id()}");
   },
-  'file.replace:after' => function ($newFile,$oldFile) use ($gitHelper) {
-    $gitHelper->changeHandler("Replaced File: {$newFile->id()}");
+  'file.replace:after' => function ($newFile,$oldFile) {
+    site()->git()->changeHandler("Replaced File: {$newFile->id()}");
   },
 
   /**
   * Site-Hooks
   */
-  'site.update:after' => function ($newSite,$oldSite) use ($gitHelper) {
-    $gitHelper->changeHandler("Edited Site");
+  'site.update:after' => function ($newSite,$oldSite) {
+    site()->git()->changeHandler("Edited Site");
   },
 
   /**
   * Avatar-Hooks
   */
-  'avatar.create:after' => function ($avatar) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'avatar.create:after' => function ($avatar) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $avatar->user()->name() ?? $avatar->user()->email();
-    $gitHelper->changeHandler("Uploaded Avatar: {$name}");
+    site()->git()->changeHandler("Uploaded Avatar: {$name}");
   },
-  'avatar.replace:after' => function ($newAvatar, $oldAvatar) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'avatar.replace:after' => function ($newAvatar, $oldAvatar) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $newAvatar->user()->name() ?? $newAvatar->user()->email();
-    $gitHelper->changeHandler("Replaced Avatar: {$name}");
+    site()->git()->changeHandler("Replaced Avatar: {$name}");
   },
-  'avatar.delete:after' => function ($status, $avatar) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'avatar.delete:after' => function ($status, $avatar) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $avatar->user()->name() ?? $avatar->user()->email();
-    $gitHelper->changeHandler("Deleted Avatar: {$name}");
+    site()->git()->changeHandler("Deleted Avatar: {$name}");
   },
 
   /**
   * User-Hooks
   */
-  'user.changeEmail:after' => function ($newUser, $oldUser) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.changeEmail:after' => function ($newUser, $oldUser) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $newUser->name() ?? $newUser->email();
     $oldEmail = $oldUser->email() ?? "None";
-    $gitHelper->changeHandler("Changed E-Mail: {$name} ({$oldEmail} → {$newUser->email()})");
+    site()->git()->changeHandler("Changed E-Mail: {$name} ({$oldEmail} → {$newUser->email()})");
   },
-  'user.changeName:after' => function ($newUser, $oldUser) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.changeName:after' => function ($newUser, $oldUser) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $newUser->name() ?? $newUser->email();
     $oldName = $oldUser->name() ?? "None";
     $newName = $newUser->name() ?? "None";
-    $gitHelper->changeHandler("Changed Name: {$name} ({$oldName} → {$newName})");
+    site()->git()->changeHandler("Changed Name: {$name} ({$oldName} → {$newName})");
   },
-  'user.changeLanguage:after' => function ($newUser, $oldUser) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.changeLanguage:after' => function ($newUser, $oldUser) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $newUser->name() ?? $newUser->email();
     $oldLang = $oldUser->language() ?? "None";
-    $gitHelper->changeHandler("Changed Language: {$name} ({$oldLang} → {$newUser->language()})");
+    site()->git()->changeHandler("Changed Language: {$name} ({$oldLang} → {$newUser->language()})");
   },
-  'user.changePassword:after' => function ($newUser, $oldUser) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.changePassword:after' => function ($newUser, $oldUser) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $newUser->name() ?? $newUser->email();
-    $gitHelper->changeHandler("Changed Password: {$name}");
+    site()->git()->changeHandler("Changed Password: {$name}");
   },
-  'user.changeRole:after' => function ($newUser, $oldUser) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.changeRole:after' => function ($newUser, $oldUser) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $newUser->name() ?? $newUser->email();
     $oldRole = $oldUser->role() ?? "None";
-    $gitHelper->changeHandler("Changed Role: {$name} ({$oldRole} → {$newUser->role()})");
+    site()->git()->changeHandler("Changed Role: {$name} ({$oldRole} → {$newUser->role()})");
   },
-  'user.create:after' => function ($user) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.create:after' => function ($user) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $user->name() ?? $user->email();
-    $gitHelper->changeHandler("Created User: {$name}");
+    site()->git()->changeHandler("Created User: {$name}");
   },
-  'user.update:after' => function ($newUser,$oldUser) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.update:after' => function ($newUser,$oldUser) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $newUser->name() ?? $newUser->email();
-    $gitHelper->changeHandler("Edited User: {$name}");
+    site()->git()->changeHandler("Edited User: {$name}");
   },
-  'user.delete:after' => function ($status, $user) use ($gitHelper) {
-    if (!$gitHelper->userHooksEnabled()) return;
+  'user.delete:after' => function ($status, $user ) {
+    if (!site()->git()->userHooksEnabled()) return;
     $name = $user->name() ?? $user->email();
-    $gitHelper->changeHandler("Deleted User: {$name}");
+    site()->git()->changeHandler("Deleted User: {$name}");
   },
 
 ];

--- a/index.php
+++ b/index.php
@@ -1,8 +1,6 @@
 <?php
 
 require_once __DIR__ . DS . 'GitHelper.php';
-$gitHelper = new GitHelper();
-
 
 Kirby::plugin('wottpal/git', [
 
@@ -22,5 +20,9 @@ Kirby::plugin('wottpal/git', [
   'hooks' => require_once __DIR__ . DS . 'hooks.php',
 
   'fields' => require_once __DIR__ . DS . 'fields.php',
+
+  'siteMethods' => [
+    'git' => require_once __DIR__ . DS . 'src' . DS . 'siteMethods/git.php'
+  ]
 
 ]);

--- a/src/siteMethods/git.php
+++ b/src/siteMethods/git.php
@@ -1,0 +1,10 @@
+<?php
+
+return function() {
+  static $git = null; 
+  if (!$git) {
+    $git = new GitHelper;
+  }
+
+  return $git;
+};


### PR DESCRIPTION
This change makes the git helper available to other plugins through a `sideMethods` function.

This allows other plugins to temporarily disable the commit features, reset it later or commit on behalf of the git plugin.